### PR TITLE
MYST-195 Add missing fields for new sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,11 +95,11 @@ def session_stats_create(session_key):
     session = Session.query.get(session_key)
     if session is None:
         session = Session(session_key)
-        session.client_updated_at = datetime.utcnow()
         session.client_ip = request.remote_addr
 
     session.client_bytes_sent = bytes_sent
     session.client_bytes_received = bytes_received
+    session.client_updated_at = datetime.utcnow()
 
     db.session.add(session)
     db.session.commit()

--- a/app.py
+++ b/app.py
@@ -95,6 +95,8 @@ def session_stats_create(session_key):
     session = Session.query.get(session_key)
     if session is None:
         session = Session(session_key)
+        session.client_updated_at = datetime.utcnow()
+        session.client_ip = request.remote_addr
 
     session.client_bytes_sent = bytes_sent
     session.client_bytes_received = bytes_received

--- a/tests/test.py
+++ b/tests/test.py
@@ -87,6 +87,7 @@ class TestApi(TestCase):
         self.assertEqual('123', session.session_key)
         self.assertEqual(20, session.client_bytes_sent)
         self.assertEqual(40, session.client_bytes_received)
+        self.assertIsNotNone(session.client_updated_at)
 
     def test_session_stats_create_with_negative_values(self):
         re = self._post('/v1/sessions/123/stats', {'bytes_sent': -20, 'bytes_received': 40})

--- a/tests/test.py
+++ b/tests/test.py
@@ -69,6 +69,8 @@ class TestApi(TestCase):
         self.assertEqual('123', session.session_key)
         self.assertEqual(20, session.client_bytes_sent)
         self.assertEqual(40, session.client_bytes_received)
+        self.assertIsNotNone(session.client_updated_at)
+        self.assertEqual('127.0.0.1', session.client_ip)
 
     def test_session_stats_create_with_session(self):
         session = Session('123')

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,7 +19,6 @@ class TestApi(TestCase):
         re = self._post('/v1/node_register', payload)
         self.assertEqual(200, re.status_code)
 
-        print re.data
         re.json
 
     def test_proposals(self):
@@ -116,7 +115,6 @@ class TestApi(TestCase):
 
         re = self._post('/v1/node_send_stats', payload)
 
-        print re.data
         data = json.loads(re.data)
         for el in data['sessions']:
             el['is_session_valid']
@@ -132,7 +130,6 @@ class TestApi(TestCase):
 
         re = self._post('/v1/client_send_stats', payload)
 
-        print re.data
         data = json.loads(re.data)
         data['is_session_valid']
         data['session_key']

--- a/tests/test_save_identity.py
+++ b/tests/test_save_identity.py
@@ -12,7 +12,6 @@ class TestApi(TestCase):
         }
 
         re = self.client.post('/v1/identities', data=json.dumps(payload))
-        print re.data
         self.assertEqual(200, re.status_code)
 
 


### PR DESCRIPTION
These values previously were set in session creation endpoint, which was removed. Now, these values are set when new session_key is received when receiving stats and session is created.