### PR TITLE
MYST-196 Remove client_send_stats endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,7 @@ def proposals():
     return jsonify({'proposals': service_proposals})
 
 
-# Node and client should call this endpoint each minute.
+# Client calls this endpoint each minute.
 @app.route('/v1/sessions/<session_key>/stats', methods=['POST'])
 @validate_json
 def session_stats_create(session_key):
@@ -163,40 +163,6 @@ def node_send_stats():
     return jsonify(
     {
         'sessions': return_values
-    })
-
-
-# Client call this function each minute.
-@app.route('/v1/client_send_stats', methods=['POST'])
-@validate_json
-def client_send_stats():
-    payload = request.get_json(force=True)
-    session_key = payload.get('session_key', '')
-    bytes_sent = payload.get('bytes_sent', 0)
-    bytes_received = payload.get('bytes_received', 0)
-
-    # get session by key
-    session = Session.query.get(session_key)
-    is_session_valid = False
-
-    if not session:
-        return jsonify(error='session key not found'), 400
-
-    if session:
-        # TODO: add this checking as soon as send stats is implemented in node
-        #if session.established:
-        if bytes_sent >= 0 and bytes_received >= 0:
-            session.client_bytes_sent = bytes_sent
-            session.client_bytes_received = bytes_received
-            session.client_updated_at = datetime.utcnow()
-            db.session.add(session)
-            db.session.commit()
-            is_session_valid = True
-
-    return jsonify(
-    {
-        'session_key': session_key,
-        'is_session_valid': is_session_valid
     })
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -100,25 +100,26 @@ class TestApi(TestCase):
         sessions = Session.query.all()
         self.assertEqual(0, len(sessions))
 
-    # TODO: fix test
-    def _test_node_send_stats(self):
+    def test_node_send_stats(self):
+        self._register_node()
+
         session = {
             'session_key': 'X2d9gyQk1j',
             'bytes_sent': 20,
             'bytes_received': 10,
         }
-
         payload = {
-            'node_key': 'node key',
+            'node_key': 'node1',
             'sessions': [session]
         }
 
         re = self._post('/v1/node_send_stats', payload)
 
-        data = json.loads(re.data)
-        for el in data['sessions']:
-            el['is_session_valid']
-            el['session_key']
+        sessions = re.json['sessions']
+        self.assertEqual(1, len(sessions))
+        for session in sessions:
+            self.assertIsNotNone(session['is_session_valid'])
+            self.assertEqual('X2d9gyQk1j', session['session_key'])
 
     def _get(self, url, params={}):
         return self.client.get(url, query_string=params)

--- a/tests/test.py
+++ b/tests/test.py
@@ -120,20 +120,6 @@ class TestApi(TestCase):
             el['is_session_valid']
             el['session_key']
 
-    # TODO: fix test
-    def _test_client_send_stats(self):
-        payload = {
-            'session_key': 'X2d9gyQk1j',
-            'bytes_sent': 50,
-            'bytes_received': 60,
-        }
-
-        re = self._post('/v1/client_send_stats', payload)
-
-        data = json.loads(re.data)
-        data['is_session_valid']
-        data['session_key']
-
     def _get(self, url, params={}):
         return self.client.get(url, query_string=params)
 


### PR DESCRIPTION
This is not needed anymore, because `POST /v1/sessions/<session_key>/stats` is used instead.