### PR TITLE
Migrate node proposals column to fix proposals endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,7 +57,7 @@ def node_register():
         node = Node(node_key)
 
     node.ip = request.remote_addr
-    node.connection_config = request.data
+    node.proposal = json.dumps(proposal)
     node.updated_at = datetime.utcnow()
     db.session.add(node)
     db.session.commit()

--- a/migrations/versions/90f976272da9_.py
+++ b/migrations/versions/90f976272da9_.py
@@ -1,0 +1,24 @@
+"""Rename node.connection_config
+
+Revision ID: 90f976272da9
+Revises: 3d7bcbbf6cc4
+Create Date: 2018-01-08 10:48:14.069122
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '90f976272da9'
+down_revision = '3d7bcbbf6cc4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('node', sa.Column('proposal', sa.Text()))
+
+
+def downgrade():
+    op.drop_column('node', 'proposal')

--- a/migrations/versions/9f7a13ec4cef_.py
+++ b/migrations/versions/9f7a13ec4cef_.py
@@ -1,0 +1,46 @@
+"""empty message
+
+Revision ID: 9f7a13ec4cef
+Revises: 90f976272da9
+Create Date: 2018-01-08 11:27:42.117647
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+import json
+
+from models import db, Node
+from app import app
+
+revision = '9f7a13ec4cef'
+down_revision = '90f976272da9'
+branch_labels = None
+depends_on = None
+
+db.init_app(app)
+
+
+def upgrade():
+    for node in Node.query.all():
+        proposal = parse_proposal(node.connection_config)
+        proposal_string = json.dumps(proposal) if proposal else ''
+        node.proposal = proposal_string
+
+    db.session.commit()
+
+
+def parse_proposal(string):
+    try:
+        data = json.loads(string)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data.get('service_proposal')
+
+
+def downgrade():
+    pass

--- a/models.py
+++ b/models.py
@@ -15,6 +15,7 @@ class Node(db.Model):
     node_key = db.Column(db.String(NODE_KEY_LIMIT), primary_key=True)
     ip = db.Column(db.String(45))
     connection_config = db.Column(db.Text)
+    proposal = db.Column(db.Text)
     created_at = db.Column(db.DateTime)
     updated_at = db.Column(db.DateTime)
 

--- a/models.py
+++ b/models.py
@@ -29,14 +29,10 @@ class Node(db.Model):
 
     def get_service_proposals(self):
         try:
-            config = json.loads(self.connection_config)
+            proposal = json.loads(self.proposal)
         except ValueError:
-            return None
-
-        service_proposal = config.get('service_proposal')
-        if service_proposal is None:
-            return None
-        return [service_proposal]
+            return []
+        return [proposal]
 
 
 class Session(db.Model):


### PR DESCRIPTION
Migration converts invalid proposals to an empty list of proposals. This is a safer step without deleting nodes - later, we can remove nodes with no proposals if we want to.

Also, saving only proposals in column instead of full `request.data`.