### PR TITLE
multiple proposal support

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -36,9 +36,9 @@ def main():
     return page_content
 
 
-@app.route('/node/<key>')
-def node(key):
-    node = model_layer.get_node_info(key)
+@app.route('/node/<key>/<service_type>')
+def node(key, service_type):
+    node = model_layer.get_node_info(key, service_type)
     return render_template(
         'node.html',
         node=node,

--- a/dashboard/model_layer.py
+++ b/dashboard/model_layer.py
@@ -1,6 +1,6 @@
 import models
 from queries import filter_active_sessions, filter_active_nodes
-from queries import count_active_nodes
+from queries import get_active_nodes_count_query
 from datetime import datetime, timedelta
 import humanize
 import dashboard.helpers as helpers
@@ -12,7 +12,7 @@ def get_db():
 
 
 def get_active_nodes_count():
-    count = count_active_nodes().first()
+    count = get_active_nodes_count_query().first()
     if len(count) == 1:
         return count[0]
     return 0

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -50,6 +50,7 @@
                       <tr>
                         <th>#</th>
                         <th>Node Key</th>
+                        <th>Service Type</th>
                         <th>Country</th>
                         <th>Sessions</th>
                         <th>Seen</th>
@@ -57,9 +58,10 @@
                     </thead>
                     <tbody>
                       {% for node in available_nodes %}
-                      <tr onclick="window.document.location='/node/{{node.node_key}}'">
+                      <tr onclick="window.document.location='/node/{{node.node_key}}/{{node.service_type}}'">
                         <th scope="row">{{loop.index}}</th>
                         <td>{{node.node_key}}</td>
+                        <td>{{node.service_type}}</td>
                         <td>{{node.country_string}}</td>
                         <td>{{node.sessions_count}}</td>
                         <td>{{node.last_seen}}</td>

--- a/dashboard/templates/node.html
+++ b/dashboard/templates/node.html
@@ -50,7 +50,7 @@
                 </li>
                 <li>
                   <span class="name">Transport Protocols</span>
-                  <span class="value">OpenVPN (TCP,UDP)</span>
+                  <span class="value">{{ node.service_type }}</span>
                 </li>
               </ul>
             </div>

--- a/dashboard/templates/nodes.html
+++ b/dashboard/templates/nodes.html
@@ -31,6 +31,7 @@
                   <th>#</th>
                   <th>Node Key</th>
                   <th>Country</th>
+                  <th>Service Type</th>
                   <th>Seen</th>
                   <th>Sessions Total</th>
                   <th>Status</th>
@@ -38,10 +39,11 @@
               </thead>
               <tbody>
                 {% for node in nodes %}
-                <tr onclick="window.document.location='/node/{{node.node_key}}'">
+                <tr onclick="window.document.location='/node/{{node.node_key}}/{{node.service_type}}'">
                   <th scope="row">{{loop.index}}</th>
                   <td>{{node.node_key}}</td>
                   <td>{{node.country_string}}</td>
+                  <td>{{node.service_type}}</td>
                   <td>{{node.last_seen}}</td>
                   <td>{{node.sessions_count}}</td>
                   <td>{{node.status}}</td>

--- a/dashboard/templates/session.html
+++ b/dashboard/templates/session.html
@@ -42,11 +42,11 @@
                 </li>
                 <li>
                   <span class="name">Node</span>
-                  <span class="value"><a href="/node/{{ session.node_key }}">{{ session.shortened_node_key }}</a></span>
+                  <span class="value"><a href="/node/{{ session.node_key }}/{{ session.service_type }}">{{ session.shortened_node_key }}</a></span>
                 </li>
                 <li>
                   <span class="name">Protocol</span>
-                  <span class="value">OpenVPN (UDP)</span>
+                  <span class="value">{{ session.service_type }}</span>
                 </li>
               </ul>
             </div>

--- a/fixtures.py
+++ b/fixtures.py
@@ -15,7 +15,7 @@ def create_fixtures():
 
 
 def _create_node():
-    node = Node("test node")
+    node = Node("test node", "dummy")
     node.updated_at = datetime.utcnow()
     node.proposal = '{}'
     return node

--- a/migrations/versions/0cce46ad632d_.py
+++ b/migrations/versions/0cce46ad632d_.py
@@ -1,0 +1,31 @@
+"""add indices
+
+Revision ID: 0cce46ad632d
+Revises: 7eaa506f41dc
+Create Date: 2018-11-06 11:54:11.473467
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '0cce46ad632d'
+down_revision = '7eaa506f41dc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('session_fast_count_index', 'session', ['client_updated_at'], unique=False)
+    op.create_index('node_availability_fast_stats_index', 'node_availability', ['node_key', 'date'], unique=False)
+    op.create_index('node_fast_active_count_index', 'node', ['updated_at'], unique=False)
+    op.create_index('session_fast_node_index', 'session', ['node_key'], unique=False)
+
+
+def downgrade():
+    op.drop_index('node_fast_active_count_index', table_name='node')
+    op.drop_index('node_availability_fast_stats_index', table_name='node_availability')
+    op.drop_index('session_fast_count_index', table_name='session')
+    op.drop_index('session_fast_node_index', table_name='session')
+

--- a/migrations/versions/6a151731efac_.py
+++ b/migrations/versions/6a151731efac_.py
@@ -1,0 +1,31 @@
+"""change node primary key to a composite
+
+Revision ID: 6a151731efac
+Revises: 0cce46ad632d
+Create Date: 2018-11-06 13:13:24.966616
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '6a151731efac'
+down_revision = '0cce46ad632d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+    ALTER TABLE node DROP PRIMARY KEY, ADD PRIMARY KEY(node_key, service_type);
+    """)
+    op.add_column('session', sa.Column('service_type', mysql.VARCHAR(length=255), server_default=sa.text("'openvpn'"), nullable=False))
+    op.add_column('node_availability', sa.Column('service_type', mysql.VARCHAR(length=255), server_default=sa.text("'openvpn'"), nullable=False))
+
+def downgrade():
+    op.execute("""
+    ALTER TABLE node DROP PRIMARY KEY, ADD PRIMARY KEY(node_key);
+    """) 
+    op.drop_column('session', 'service_type')
+    op.drop_column('node_availability', 'service_type')

--- a/models.py
+++ b/models.py
@@ -19,10 +19,11 @@ class Node(db.Model):
     proposal = db.Column(db.Text)
     created_at = db.Column(db.DateTime)
     updated_at = db.Column(db.DateTime)
-    service_type = db.Column(db.Text)
+    service_type = db.Column(db.String(255), primary_key=True)
 
-    def __init__(self, node_key):
+    def __init__(self, node_key, service_type):
         self.node_key = node_key
+        self.service_type = service_type
         self.created_at = datetime.utcnow()
 
     def is_active(self):
@@ -68,6 +69,7 @@ class Session(db.Model):
     client_ip = db.Column(db.String(45))
     client_country = db.Column(db.String(255))
     established = db.Column(db.Boolean)
+    service_type = db.Column(db.String(255))
 
     def __init__(self, session_key):
         self.session_key = session_key
@@ -87,6 +89,7 @@ class NodeAvailability(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     node_key = db.Column(db.String(IDENTITY_LENGTH_LIMIT))
     date = db.Column(db.DateTime)
+    service_type = db.Column(db.String(255))
 
     def __init__(self, node_key):
         self.node_key = node_key

--- a/queries.py
+++ b/queries.py
@@ -3,7 +3,7 @@ from models import Node, Session, AVAILABILITY_TIMEOUT
 from sqlalchemy import func, distinct
 
 
-def count_active_nodes():
+def get_active_nodes_count_query():
     updated_timestamp = getattr(Node, 'updated_at')
     return Node.query.with_entities(
         func.count(distinct(Node.node_key))

--- a/queries.py
+++ b/queries.py
@@ -1,5 +1,15 @@
 from datetime import datetime
 from models import Node, Session, AVAILABILITY_TIMEOUT
+from sqlalchemy import func, distinct
+
+
+def count_active_nodes():
+    updated_timestamp = getattr(Node, 'updated_at')
+    return Node.query.with_entities(
+        func.count(distinct(Node.node_key))
+    ).filter(
+        updated_timestamp >= datetime.utcnow() - AVAILABILITY_TIMEOUT
+    )
 
 
 def filter_active_nodes():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,7 +20,7 @@ class TestSession(TestCase):
 
 class TestNode(TestCase):
     def test_get_country_from_service_proposal(self):
-        node = Node("key")
+        node = Node("key", "dummy")
         node.proposal = json.dumps({
             "service_definition": {
                 "location_originate": {"country": "country code"},
@@ -32,12 +32,12 @@ class TestNode(TestCase):
         )
 
     def test_get_country_from_empty_service_proposal(self):
-        node = Node("key")
+        node = Node("key", "dummy")
         node.proposal = json.dumps({})
         self.assertIsNone(node.get_country_from_service_proposal())
 
     def test_get_country_from_invalid_service_proposal(self):
-        node = Node("key")
+        node = Node("key", "dummy")
         node.proposal = json.dumps({
             "service_definition": {}
         })

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -8,11 +8,11 @@ from queries import filter_active_nodes_by_service_type
 
 class TestQueries(TestCase):
     def test_filter_active_nodes(self):
-        node1 = Node("node1")
+        node1 = Node("node1", "dummy")
         node1.mark_activity()
         db.session.add(node1)
 
-        node2 = Node("node2")
+        node2 = Node("node2", "dummy")
         db.session.add(node2)
 
         nodes = filter_active_nodes().all()
@@ -30,17 +30,12 @@ class TestQueries(TestCase):
         self.assertEqual([session1], sessions)
 
     def test_filter_active_nodes_by_service_type(self):
-        dummy_node = Node("node1")
+        dummy_node = Node("node1", "dummy")
         dummy_node.mark_activity()
-        dummy_node.service_type = "dummy"
         db.session.add(dummy_node)
 
-        no_service_type_node = Node("node2")
-        db.session.add(no_service_type_node)
-
-        openvpn_node = Node("node3")
+        openvpn_node = Node("node3", "openvpn")
         openvpn_node.mark_activity()
-        openvpn_node.service_type = "openvpn"
         db.session.add(openvpn_node)
 
         dummy_nodes = filter_active_nodes_by_service_type("dummy").all()


### PR DESCRIPTION
Changed the PK of node to a composite(node_key,service_type). Also changed all the relevant endpoints to accept service type as a parameter. In order to maintain backwards compatibility - added a default service type(openvpn) to the mentioned endpoints.

Made the relevant changes to the dashboard as well as added extra columns on dashboard where appropriate(service_type).

Optimized some of the queries on the dashboard side, so it should stop lagging(currently some requests take upwards of 30s on the running version of discovery).

BONUS: Added indexes to relevant fields to help with speedier querying.


closes #82 