### PR TITLE
Change dashboard session duration format

### DIFF
--- a/dashboard/helpers.py
+++ b/dashboard/helpers.py
@@ -2,6 +2,7 @@ import models
 import humanize
 from datetime import timedelta
 
+
 def shorten_node_key(node_key):
     if node_key and len(node_key) == models.IDENTITY_LENGTH_LIMIT:
         return node_key[:6] + '..' + node_key[-4:]

--- a/dashboard/helpers.py
+++ b/dashboard/helpers.py
@@ -17,14 +17,13 @@ def get_natural_size(value):
 
 
 def format_duration(duration: timedelta) -> str:
-    result = ''
     total_seconds = duration.total_seconds()
     if total_seconds < 60:
-        result = '< 1 minute'
-    else:
-        total_minutes, _ = divmod(total_seconds, 60)
-        hours, minutes = divmod(total_minutes, 60)
-        if hours > 0:
-            result += '%dhr ' % hours
-        result += '%dmin' % minutes
+        return '< 1 minute'
+    total_minutes, _ = divmod(total_seconds, 60)
+    hours, minutes = divmod(total_minutes, 60)
+    result = ''
+    if hours > 0:
+        result += '%dhr ' % hours
+    result += '%dmin' % minutes
     return result

--- a/dashboard/helpers.py
+++ b/dashboard/helpers.py
@@ -1,6 +1,6 @@
 import models
 import humanize
-
+from datetime import timedelta
 
 def shorten_node_key(node_key):
     if node_key and len(node_key) == models.IDENTITY_LENGTH_LIMIT:
@@ -13,3 +13,17 @@ def get_natural_size(value):
     str_value = humanize.naturalsize(value, format='%.2f', binary=True)
     # KiB -> KB, MiB - > MB, ..
     return str_value.replace('i', '')
+
+
+def format_duration(duration: timedelta) -> str:
+    result = ''
+    total_seconds = duration.total_seconds()
+    if total_seconds < 60:
+        result = '< 1 minute'
+    else:
+        total_minutes, _ = divmod(total_seconds, 60)
+        hours, minutes = divmod(total_minutes, 60)
+        if hours > 0:
+            result += '%dhr ' % hours
+        result += '%dmin' % minutes
+    return result

--- a/dashboard/model_layer.py
+++ b/dashboard/model_layer.py
@@ -185,10 +185,7 @@ def get_node_info(node_key, service_type):
 
 def enrich_session_info(se):
     duration = (se.node_updated_at or se.client_updated_at) - se.created_at
-    duration_seconds = duration.total_seconds()
-    m, s = divmod(duration_seconds, 60)
-    h, m = divmod(m, 60)
-    se.duration = "%d:%02d:%02d" % (h, m, s)
+    se.duration = helpers.format_duration(duration)
     se.data_sent = helpers.get_natural_size(se.client_bytes_sent)
     se.data_received = helpers.get_natural_size(se.client_bytes_received)
     se.data_transferred = helpers.get_natural_size(

--- a/dashboard/tests/test_helpers.py
+++ b/dashboard/tests/test_helpers.py
@@ -1,5 +1,7 @@
 import unittest
-from dashboard.helpers import shorten_node_key, get_natural_size, format_duration
+from dashboard.helpers import (
+    shorten_node_key, get_natural_size, format_duration
+)
 from datetime import timedelta
 
 

--- a/dashboard/tests/test_helpers.py
+++ b/dashboard/tests/test_helpers.py
@@ -1,5 +1,6 @@
 import unittest
-from dashboard.helpers import shorten_node_key, get_natural_size
+from dashboard.helpers import shorten_node_key, get_natural_size, format_duration
+from datetime import timedelta
 
 
 class TestHelpers(unittest.TestCase):
@@ -40,4 +41,30 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(
             '1.00 GB',
             get_natural_size(1024 * 1024 * 1024)
+        )
+
+    def test_format_duration(self):
+        self.assertEqual(
+            '< 1 minute',
+            format_duration(timedelta(seconds=0))
+        )
+
+        self.assertEqual(
+            '< 1 minute',
+            format_duration(timedelta(seconds=59))
+        )
+
+        self.assertEqual(
+            '1min',
+            format_duration(timedelta(seconds=60))
+        )
+
+        self.assertEqual(
+            '1hr 0min',
+            format_duration(timedelta(minutes=60))
+        )
+
+        self.assertEqual(
+            '100hr 1min',
+            format_duration(timedelta(hours=100, minutes=1))
         )


### PR DESCRIPTION
Closes #84 
- Changes session duration format from hours:minutes:seconds "10:11:12" to "10hr 11min"
- Don't show seconds anymore, because session duration precision is one minute