### PR TITLE
Session expiration

### DIFF
--- a/app.py
+++ b/app.py
@@ -249,6 +249,11 @@ def session_stats_create(session_key, caller_identity):
         message = 'session identity does not match current one'
         return jsonify(error=message), 403
 
+    if session.has_expired():
+        return jsonify(
+            error='session has expired'
+        ), 400
+
     session.client_bytes_sent = bytes_sent
     session.client_bytes_received = bytes_received
     session.client_updated_at = datetime.utcnow()

--- a/models.py
+++ b/models.py
@@ -9,6 +9,7 @@ db = SQLAlchemy()
 IDENTITY_LENGTH_LIMIT = 42
 SESSION_KEY_LIMIT = 36
 AVAILABILITY_TIMEOUT = timedelta(minutes=2)
+SESSION_EXPIRATION = timedelta(minutes=10)
 
 
 class Node(db.Model):
@@ -82,6 +83,10 @@ class Session(db.Model):
 
     def is_active(self):
         return _is_active(self.client_updated_at)
+
+    def has_expired(self):
+        last_session_activity = self.client_updated_at or self.created_at
+        return datetime.utcnow() - last_session_activity > SESSION_EXPIRATION
 
 
 class NodeAvailability(db.Model):


### PR DESCRIPTION
- Session stats are discarded to update if sent 10 minutes after since session was last time updated or created