### PR TITLE
instruct browsers to cache content max 10 min

### DIFF
--- a/dashboard/templates/layout.html
+++ b/dashboard/templates/layout.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Cache-Control" content="max-age=600">
 
     <title>Mysterium Network | Dashboard</title>
 


### PR DESCRIPTION
Currently browsers show old nonsense and almost never expire it.