### PR TITLE
Endpoint for storing payout parameters

### DIFF
--- a/app.py
+++ b/app.py
@@ -310,10 +310,10 @@ def save_identity(caller_identity):
 
 
 # End Point which creates or updates payout info next to identity
-@app.route('/v1/identities/<identity_url_param>/payout', methods=['POST'])
+@app.route('/v1/identities/<identity_url_param>/payout', methods=['PUT'])
 @validate_json
 @recover_identity
-def update_payout_info(identity_url_param, caller_identity):
+def set_payout_info(identity_url_param, caller_identity):
     payload = request.get_json(force=True)
 
     payout_eth_address = payload.get('payout_eth_address', None)

--- a/app.py
+++ b/app.py
@@ -322,7 +322,7 @@ def update_payout_info(identity_url_param, caller_identity):
         return jsonify(error=msg), 400
 
     if identity_url_param.lower() != caller_identity:
-        msg = 'identity parameter in url does not match with signer identity'
+        msg = 'no permission to modify this identity'
         return jsonify(error=msg), 403
 
     if not is_valid_eth_address(payout_eth_address):
@@ -333,12 +333,11 @@ def update_payout_info(identity_url_param, caller_identity):
     if record:
         record.update(payout_eth_address)
         db.session.add(record)
-        db.session.commit()
     else:
         new_record = IdentityRegistration(caller_identity, payout_eth_address)
         db.session.add(new_record)
-        db.session.commit()
 
+    db.session.commit()
     return jsonify({})
 
 

--- a/migrations/versions/f448930e4058_.py
+++ b/migrations/versions/f448930e4058_.py
@@ -23,8 +23,6 @@ def upgrade():
         sa.Column('created_at', sa.DateTime(), nullable=True),
         sa.Column('updated_at', sa.DateTime(), nullable=True),
         sa.Column('payout_eth_address', sa.String(length=42), nullable=True),
-        sa.Column('signed_body', sa.String(length=1023), nullable=True),
-        sa.Column('signature', sa.String(length=255), nullable=True),
         sa.PrimaryKeyConstraint('identity')
     )
 

--- a/migrations/versions/f448930e4058_.py
+++ b/migrations/versions/f448930e4058_.py
@@ -1,0 +1,33 @@
+"""create table identity_registration
+
+Revision ID: f448930e4058
+Revises: 6a151731efac
+Create Date: 2019-03-04 15:50:52.395995
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'f448930e4058'
+down_revision = '6a151731efac'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'identity_registration',
+        sa.Column('identity', sa.String(length=42), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('payout_eth_address', sa.String(length=42), nullable=True),
+        sa.Column('signed_body', sa.String(length=1023), nullable=True),
+        sa.Column('signature', sa.String(length=255), nullable=True),
+        sa.PrimaryKeyConstraint('identity')
+    )
+
+
+def downgrade():
+    op.drop_table('identity_registration')

--- a/models.py
+++ b/models.py
@@ -115,3 +115,20 @@ def _is_active(last_update_time):
     if last_update_time is None:
         return False
     return last_update_time > datetime.utcnow() - AVAILABILITY_TIMEOUT
+
+
+class IdentityRegistration(db.Model):
+    __tablename__ = 'identity_registration'
+    identity = db.Column(db.String(IDENTITY_LENGTH_LIMIT), primary_key=True)
+    created_at = db.Column(db.DateTime)
+    updated_at = db.Column(db.DateTime)
+    payout_eth_address = db.Column(db.String(IDENTITY_LENGTH_LIMIT))
+    signed_body = db.Column(db.String(1023))
+    signature = db.Column(db.String(255))
+
+    def __init__(self, identity, payout_eth_address, signed_body, signature):
+        self.identity = identity
+        self.created = datetime.utcnow()
+        self.payout_eth_address = payout_eth_address
+        self.signed_body = signed_body
+        self.signature = signature

--- a/models.py
+++ b/models.py
@@ -123,12 +123,12 @@ class IdentityRegistration(db.Model):
     created_at = db.Column(db.DateTime)
     updated_at = db.Column(db.DateTime)
     payout_eth_address = db.Column(db.String(IDENTITY_LENGTH_LIMIT))
-    signed_body = db.Column(db.String(1023))
-    signature = db.Column(db.String(255))
 
-    def __init__(self, identity, payout_eth_address, signed_body, signature):
+    def __init__(self, identity, payout_eth_address):
         self.identity = identity
-        self.created = datetime.utcnow()
+        self.created_at = datetime.utcnow()
         self.payout_eth_address = payout_eth_address
-        self.signed_body = signed_body
-        self.signature = signature
+
+    def update(self, payout_eth_address):
+        self.updated_at = datetime.utcnow()
+        self.payout_eth_address = payout_eth_address

--- a/templates/api.html
+++ b/templates/api.html
@@ -20,7 +20,7 @@
 <div>Most parameters should be encoded in JSON and passed as HTTP body data.</div>
 <div>Returned values are encoded in JSON.</div>
 <div>Each endpoint returns status code. For example status code 200 means success.</div>
-<div>For POST methods Authorization header with signature is required.</div>
+<div>For POST and PUT methods Authorization header with signature is required.</div>
 
 <div class="endpoint">
     <div class="title">POST /v1/register_proposal</div>
@@ -153,8 +153,8 @@
 </div>
 
 <div class="endpoint">
-    <div class="title">POST /v1/identities/{identity}/payout</div>
-    <div>Creates or updates payout info for identity.</div>
+    <div class="title">PUT /v1/identities/{identity}/payout</div>
+    <div>Sets payout info for identity.</div>
     <div>Example JSON parameters:</div>
     <pre>
     {

--- a/templates/api.html
+++ b/templates/api.html
@@ -154,11 +154,10 @@
 
 <div class="endpoint">
     <div class="title">POST /v1/identities/{identity}/payout</div>
-    <div>Creates payout info for identity.</div>
+    <div>Creates or updates payout info for identity.</div>
     <div>Example JSON parameters:</div>
     <pre>
     {
-        "identity": "0x0000000000000000000000000000000000000001",
         "payout_eth_address": "0x000000000000000000000000000000000000000A"
     }
     </pre>

--- a/templates/api.html
+++ b/templates/api.html
@@ -115,7 +115,7 @@
     <div>Example JSON parameters:</div>
     <pre>
     {
-        "service_type": "openvpn"
+        "service_type": "openvpn",
         "bytes_sent": 1024,
         "bytes_received": 1024,
         "provider_id": "0x0000000000000000000000000000000000000001",
@@ -146,6 +146,22 @@
 <div class="endpoint">
     <div class="title">POST /v1/identities</div>
     <div>Saves new identity.</div>
+    <div>Returns:</div>
+    <pre>
+    {}
+    </pre>
+</div>
+
+<div class="endpoint">
+    <div class="title">POST /v1/identities/{identity}/payout</div>
+    <div>Creates payout info for identity.</div>
+    <div>Example JSON parameters:</div>
+    <pre>
+    {
+        "identity": "0x0000000000000000000000000000000000000001",
+        "payout_eth_address": "0x000000000000000000000000000000000000000A"
+    }
+    </pre>
     <div>Returns:</div>
     <pre>
     {}

--- a/tests/endpoints/test_identities.py
+++ b/tests/endpoints/test_identities.py
@@ -1,35 +1,16 @@
 from tests.test_case import TestCase, main
 from tests.utils import (
     generate_test_authorization,
-    generate_static_public_address,
-    sign_message_with_static_key
+    generate_static_public_address
 )
 from models import IdentityRegistration
 import json
-import base64
 
 
 class TestPost(TestCase):
-    def test_identity_payout_no_provider_id(self):
+    def test_payout_no_payout_address(self):
         identity = generate_static_public_address().upper()
-        payload = {
-            'payout_eth_address': ''
-        }
-        auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
-            '/v1/identities/{}/payout'.format(identity),
-            payload,
-            headers=auth['headers']
-        )
-        msg = 'missing identity parameter in body'
-        self.assertEqual({'error': msg}, re.json)
-        self.assertEqual(400, re.status_code)
-
-    def test_identity_payout_no_payout_address(self):
-        identity = generate_static_public_address().upper()
-        payload = {
-            'identity': ''
-        }
+        payload = {}
         auth = generate_test_authorization(json.dumps(payload))
         re = self._post(
             '/v1/identities/{}/payout'.format(identity),
@@ -40,11 +21,9 @@ class TestPost(TestCase):
         self.assertEqual({'error': msg}, re.json)
         self.assertEqual(400, re.status_code)
 
-    def test_identity_payout_url_parameter_mismatch(self):
-        identity = generate_static_public_address().upper()
+    def test_payout_url_parameter_mismatch(self):
         payload = {
-            'identity': identity,
-            'payout_eth_address': '0x000000000000000000000000000000000000000a'
+            'payout_eth_address': '0x'
         }
         auth = generate_test_authorization(json.dumps(payload))
         re = self._post(
@@ -52,29 +31,13 @@ class TestPost(TestCase):
             payload,
             headers=auth['headers']
         )
-        msg = 'identity parameter in url does not match with provider_id'
+        msg = 'identity parameter in url does not match with signer identity'
         self.assertEqual({'error': msg}, re.json)
-        self.assertEqual(400, re.status_code)
+        self.assertEqual(403, re.status_code)
 
-    def test_identity_payout_address_mismatch_signer_identity(self):
-        payload = {
-            'identity': 'different_identity',
-            'payout_eth_address': '0x000000000000000000000000000000000000000a'
-        }
-        auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
-            '/v1/identities/different_identity/payout',
-            payload,
-            headers=auth['headers']
-        )
-        msg = 'identity parameter in body does not match with signer identity'
-        self.assertEqual({'error': msg}, re.json)
-        self.assertEqual(400, re.status_code)
-
-    def test_identity_payout_incorrect_eth_address(self):
+    def test_payout_incorrect_eth_address(self):
         identity = generate_static_public_address().upper()
         payload = {
-            'identity': identity,
             'payout_eth_address': 'any'
         }
         auth = generate_test_authorization(json.dumps(payload))
@@ -87,30 +50,9 @@ class TestPost(TestCase):
         self.assertEqual({'error': msg}, re.json)
         self.assertEqual(400, re.status_code)
 
-    def test_identity_payout_identity_already_exists(self):
-        identity = generate_static_public_address().upper()
-        model = IdentityRegistration(identity.lower(), '', '', '')
-        main.db.session.add(model)
-        main.db.session.commit()
-
-        payload = {
-            'identity': identity,
-            'payout_eth_address': '0x000000000000000000000000000000000000000a'
-        }
-        auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
-            '/v1/identities/{}/payout'.format(identity),
-            payload,
-            headers=auth['headers']
-        )
-        msg = 'identity payout address already registered'
-        self.assertEqual({'error': msg}, re.json)
-        self.assertEqual(403, re.status_code)
-
-    def test_identity_payout_address(self):
+    def test_payout_create(self):
         identity = generate_static_public_address().upper()
         payload = {
-            'identity': identity,
             'payout_eth_address': '0x000000000000000000000000000000000000000a'
         }
         auth = generate_test_authorization(json.dumps(payload))
@@ -122,21 +64,37 @@ class TestPost(TestCase):
         self.assertEqual({}, re.json)
         self.assertEqual(200, re.status_code)
 
-        # test stored payout_eth_address
+        # test inserted values
         record = IdentityRegistration.query.get(identity.lower())
         self.assertEqual(
             '0x000000000000000000000000000000000000000a',
             record.payout_eth_address
         )
+        self.assertIsNotNone(record.created_at)
+        self.assertIsNone(record.updated_at)
 
-        # test stored signature
-        self.assertEqual(
-            sign_message_with_static_key(json.dumps(payload)),
-            base64.b64decode(record.signature)
-        )
+    def test_payout_update(self):
+        identity = generate_static_public_address().upper()
+        pre_record = IdentityRegistration(identity.lower(), '')
+        main.db.session.add(pre_record)
+        main.db.session.commit()
 
-        # test stored signed_body
-        self.assertEqual(
-            json.dumps(payload),
-            base64.b64decode(record.signed_body).decode('utf-8')
+        payload = {
+            'payout_eth_address': '0x000000000000000000000000000000000000000a'
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/{}/payout'.format(identity),
+            payload,
+            headers=auth['headers']
         )
+        self.assertEqual({}, re.json)
+        self.assertEqual(200, re.status_code)
+
+        # test updated values
+        record = IdentityRegistration.query.get(identity.lower())
+        self.assertEqual(
+            '0x000000000000000000000000000000000000000a',
+            record.payout_eth_address
+        )
+        self.assertIsNotNone(record.updated_at)

--- a/tests/endpoints/test_identities.py
+++ b/tests/endpoints/test_identities.py
@@ -31,7 +31,7 @@ class TestPost(TestCase):
             payload,
             headers=auth['headers']
         )
-        msg = 'identity parameter in url does not match with signer identity'
+        msg = 'no permission to modify this identity'
         self.assertEqual({'error': msg}, re.json)
         self.assertEqual(403, re.status_code)
 

--- a/tests/endpoints/test_identities.py
+++ b/tests/endpoints/test_identities.py
@@ -1,0 +1,142 @@
+from tests.test_case import TestCase, main
+from tests.utils import (
+    generate_test_authorization,
+    generate_static_public_address,
+    sign_message_with_static_key
+)
+from models import IdentityRegistration
+import json
+import base64
+
+
+class TestPost(TestCase):
+    def test_identity_payout_no_provider_id(self):
+        identity = generate_static_public_address().upper()
+        payload = {
+            'payout_eth_address': ''
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/{}/payout'.format(identity),
+            payload,
+            headers=auth['headers']
+        )
+        msg = 'missing identity parameter in body'
+        self.assertEqual({'error': msg}, re.json)
+        self.assertEqual(400, re.status_code)
+
+    def test_identity_payout_no_payout_address(self):
+        identity = generate_static_public_address().upper()
+        payload = {
+            'identity': ''
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/{}/payout'.format(identity),
+            payload,
+            headers=auth['headers']
+        )
+        msg = 'missing payout_eth_address parameter in body'
+        self.assertEqual({'error': msg}, re.json)
+        self.assertEqual(400, re.status_code)
+
+    def test_identity_payout_url_parameter_mismatch(self):
+        identity = generate_static_public_address().upper()
+        payload = {
+            'identity': identity,
+            'payout_eth_address': '0x000000000000000000000000000000000000000a'
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/mismatch/payout',
+            payload,
+            headers=auth['headers']
+        )
+        msg = 'identity parameter in url does not match with provider_id'
+        self.assertEqual({'error': msg}, re.json)
+        self.assertEqual(400, re.status_code)
+
+    def test_identity_payout_address_mismatch_signer_identity(self):
+        payload = {
+            'identity': 'different_identity',
+            'payout_eth_address': '0x000000000000000000000000000000000000000a'
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/different_identity/payout',
+            payload,
+            headers=auth['headers']
+        )
+        msg = 'identity parameter in body does not match with signer identity'
+        self.assertEqual({'error': msg}, re.json)
+        self.assertEqual(400, re.status_code)
+
+    def test_identity_payout_incorrect_eth_address(self):
+        identity = generate_static_public_address().upper()
+        payload = {
+            'identity': identity,
+            'payout_eth_address': 'any'
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/{}/payout'.format(identity),
+            payload,
+            headers=auth['headers']
+        )
+        msg = 'payout_eth_address is not in Ethereum address format'
+        self.assertEqual({'error': msg}, re.json)
+        self.assertEqual(400, re.status_code)
+
+    def test_identity_payout_identity_already_exists(self):
+        identity = generate_static_public_address().upper()
+        model = IdentityRegistration(identity.lower(), '', '', '')
+        main.db.session.add(model)
+        main.db.session.commit()
+
+        payload = {
+            'identity': identity,
+            'payout_eth_address': '0x000000000000000000000000000000000000000a'
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/{}/payout'.format(identity),
+            payload,
+            headers=auth['headers']
+        )
+        msg = 'identity payout address already registered'
+        self.assertEqual({'error': msg}, re.json)
+        self.assertEqual(403, re.status_code)
+
+    def test_identity_payout_address(self):
+        identity = generate_static_public_address().upper()
+        payload = {
+            'identity': identity,
+            'payout_eth_address': '0x000000000000000000000000000000000000000a'
+        }
+        auth = generate_test_authorization(json.dumps(payload))
+        re = self._post(
+            '/v1/identities/{}/payout'.format(identity),
+            payload,
+            headers=auth['headers']
+        )
+        self.assertEqual({}, re.json)
+        self.assertEqual(200, re.status_code)
+
+        # test stored payout_eth_address
+        record = IdentityRegistration.query.get(identity.lower())
+        self.assertEqual(
+            '0x000000000000000000000000000000000000000a',
+            record.payout_eth_address
+        )
+
+        # test stored signature
+        self.assertEqual(
+            sign_message_with_static_key(json.dumps(payload)),
+            base64.b64decode(record.signature)
+        )
+
+        # test stored signed_body
+        self.assertEqual(
+            json.dumps(payload),
+            base64.b64decode(record.signed_body).decode('utf-8')
+        )

--- a/tests/endpoints/test_identities.py
+++ b/tests/endpoints/test_identities.py
@@ -12,7 +12,7 @@ class TestPost(TestCase):
         identity = generate_static_public_address().upper()
         payload = {}
         auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
+        re = self._put(
             '/v1/identities/{}/payout'.format(identity),
             payload,
             headers=auth['headers']
@@ -26,7 +26,7 @@ class TestPost(TestCase):
             'payout_eth_address': '0x'
         }
         auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
+        re = self._put(
             '/v1/identities/mismatch/payout',
             payload,
             headers=auth['headers']
@@ -41,7 +41,7 @@ class TestPost(TestCase):
             'payout_eth_address': 'any'
         }
         auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
+        re = self._put(
             '/v1/identities/{}/payout'.format(identity),
             payload,
             headers=auth['headers']
@@ -56,7 +56,7 @@ class TestPost(TestCase):
             'payout_eth_address': '0x000000000000000000000000000000000000000a'
         }
         auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
+        re = self._put(
             '/v1/identities/{}/payout'.format(identity),
             payload,
             headers=auth['headers']
@@ -83,7 +83,7 @@ class TestPost(TestCase):
             'payout_eth_address': '0x000000000000000000000000000000000000000a'
         }
         auth = generate_test_authorization(json.dumps(payload))
-        re = self._post(
+        re = self._put(
             '/v1/identities/{}/payout'.format(identity),
             payload,
             headers=auth['headers']

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,6 @@
 import unittest
 import json
-
 from datetime import datetime, timedelta
-
 from models import Session, Node, NodeAvailability, AVAILABILITY_TIMEOUT
 from tests.test_case import TestCase, main
 from tests.utils import (
@@ -14,8 +12,6 @@ from identity_contract import IdentityContractFake
 
 
 class TestApi(TestCase):
-    REMOTE_ADDR = '8.8.8.8'
-
     def test_register_proposal_successful(self):
         public_address = generate_static_public_address()
         payload = {
@@ -872,21 +868,6 @@ class TestApi(TestCase):
 
         self.assertEqual(200, re.status_code)
         self.assertEqual({}, re.json)
-
-    def _get(self, url, params={}):
-        return self.client.get(
-            url,
-            query_string=params,
-            environ_base={'REMOTE_ADDR': self.REMOTE_ADDR}
-        )
-
-    def _post(self, url, payload, headers=None, remote_addr=None):
-        return self.client.post(
-            url,
-            data=json.dumps(payload),
-            headers=headers,
-            environ_base={'REMOTE_ADDR': remote_addr or self.REMOTE_ADDR}
-        )
 
     def _create_sample_node(self):
         return self._create_node("node1", "openvpn")

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,5 +1,6 @@
 from flask_testing import TestCase
 import app as main
+import json
 
 
 class TestCase(TestCase):
@@ -14,3 +15,21 @@ class TestCase(TestCase):
     def tearDown(self):
         main.db.session.remove()
         main.db.drop_all()
+
+    # TODO: find better place to move constant
+    REMOTE_ADDR = '8.8.8.8'
+
+    def _get(self, url, params={}):
+        return self.client.get(
+            url,
+            query_string=params,
+            environ_base={'REMOTE_ADDR': self.REMOTE_ADDR}
+        )
+
+    def _post(self, url, payload, headers=None, remote_addr=None):
+        return self.client.post(
+            url,
+            data=json.dumps(payload),
+            headers=headers,
+            environ_base={'REMOTE_ADDR': remote_addr or self.REMOTE_ADDR}
+        )

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -33,3 +33,11 @@ class TestCase(TestCase):
             headers=headers,
             environ_base={'REMOTE_ADDR': remote_addr or self.REMOTE_ADDR}
         )
+
+    def _put(self, url, payload, headers=None):
+        return self.client.put(
+            url,
+            data=json.dumps(payload),
+            headers=headers,
+            environ_base={'REMOTE_ADDR': self.REMOTE_ADDR}
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,8 @@ def sign_message_with_static_key(message):
 
 def generate_static_public_address():
     pk = _generate_static_private_key()
+
+    # TODO: remove .lower()
     public_address = pk.public_key.to_checksum_address().lower()
     return public_address
 


### PR DESCRIPTION
- started to separate endpoint tests by moving them out of `test_app.py` to, for example, `tests/endpoints/test_identities.py `- one test class for one endpoint 