### PR TITLE
Use actual database for tests (not sqlite) to test dashboard home

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install -r dashboard/requirements.txt
 
 script:
-  - bin/test
+  - tests/run_tests
   - bin/lint
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Install the requirements using pip
 $ pip install -r requirements.txt
 ```
 
-To execute tests, start api service in background and run:
+To execute tests:
+- Ensure that python 3.6+ is installed globally (`python --version`)
+- Run:
 ```bash
-bin/test
+tests/run_tests
 ```
 
 To run linter:

--- a/app.py
+++ b/app.py
@@ -23,8 +23,17 @@ from models import (
 
 helpers.setup_logger()
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://{}:{}@{}/{}'.format(
-    settings.USER, settings.PASSWD, settings.DB_HOST, settings.DB_NAME)
+
+
+def _generate_database_uri(db_config):
+    return 'mysql+pymysql://{}:{}@{}/{}'.format(
+        db_config['user'], db_config['passwd'], db_config['host'],
+        db_config['name'])
+
+
+app.config['SQLALCHEMY_DATABASE_URI'] =\
+    _generate_database_uri(settings.DB_CONFIG)
+
 
 migrate = Migrate(app, db)
 
@@ -390,7 +399,10 @@ def start_debug_app():
     app.run(debug=True)
 
 
-def init_db():
+def init_db(custom_config=None):
+    if custom_config is not None:
+        app.config['SQLALCHEMY_DATABASE_URI'] =\
+            _generate_database_uri(custom_config)
     db.init_app(app)
 
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,9 @@ from models import (
     db, Node, Session, NodeAvailability, Identity, IdentityRegistration
 )
 
-helpers.setup_logger()
+if not settings.DISABLE_LOGS:
+    helpers.setup_logger()
+
 app = Flask(__name__)
 
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -20,6 +20,7 @@ from flask import Flask, render_template
 from datetime import datetime
 from models import db
 import settings
+from models import db
 
 
 app = Flask(__name__)
@@ -27,8 +28,15 @@ db.init_app(app)
 
 cache = SimpleCache()
 
-app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://{}:{}@{}/{}'.format(
-    settings.USER, settings.PASSWD, settings.DB_HOST, settings.DB_NAME)
+
+def _generate_database_uri(db_config):
+    return 'mysql+pymysql://{}:{}@{}/{}'.format(
+        db_config['user'], db_config['passwd'], db_config['host'],
+        db_config['name'])
+
+
+app.config['SQLALCHEMY_DATABASE_URI'] =\
+    _generate_database_uri(settings.DB_CONFIG)
 
 
 @app.route('/')
@@ -141,6 +149,13 @@ def sessions_country():
         'sessions-country.html',
         stats=results
     )
+
+
+def init_db(custom_config=None):
+    if custom_config is not None:
+        app.config['SQLALCHEMY_DATABASE_URI'] =\
+            _generate_database_uri(custom_config)
+    db.init_app(app)
 
 
 if __name__ == '__main__':

--- a/dashboard/tests/db_queries/test_leaderboard.py
+++ b/dashboard/tests/db_queries/test_leaderboard.py
@@ -28,7 +28,7 @@ class TestGetLeaderBoardRows(TestCase):
             'session 4', 'consumer id 3',
             'provider id', 'service y', now, 3, 4
         )
-        rows = get_leaderboard_rows(now, now)
+        rows = get_leaderboard_rows(now - second, now + second)
         self.assertEqual(1, len(rows))
         self.assertEqual('provider id', rows[0].provider_id)
         self.assertEqual(4, rows[0].sessions_count)

--- a/dashboard/tests/db_queries/test_node_availability.py
+++ b/dashboard/tests/db_queries/test_node_availability.py
@@ -15,8 +15,8 @@ class TestNodeAvailability(TestCase):
         hours = get_node_hours_online(
             'node key',
             'service type',
-            now,
-            now
+            now - second,
+            now + second
         )
         self.assertEqual(1, hours)
 

--- a/dashboard/tests/test_app.py
+++ b/dashboard/tests/test_app.py
@@ -2,12 +2,10 @@ from dashboard.tests.test_case import TestCase
 
 
 class TestEndpoints(TestCase):
+    def test_main(self):
+        re = self._get('/')
+        self.assertEqual(200, re.status_code)
+
     def test_sessions(self):
         re = self._get('/sessions')
         self.assertEqual(200, re.status_code)
-
-    def _get(self, url, params={}):
-        return self.client.get(
-            url,
-            query_string=params,
-        )

--- a/dashboard/tests/test_case.py
+++ b/dashboard/tests/test_case.py
@@ -1,12 +1,18 @@
 from flask_testing import TestCase
-from dashboard.app import app
+from dashboard.app import app, init_db
 from models import db
 
 
 class TestCase(TestCase):
     def create_app(self):
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
-        db.init_app(app)
+        db_config = {
+            'host': 'localhost:33062',
+            'name': 'myst_api',
+            'user': 'myst_api',
+            'passwd': 'myst_api'
+        }
+
+        init_db(db_config)
         return app
 
     def setUp(self):
@@ -15,3 +21,9 @@ class TestCase(TestCase):
     def tearDown(self):
         db.session.remove()
         db.drop_all()
+
+    def _get(self, url, params={}):
+        return self.client.get(
+            url,
+            query_string=params,
+        )

--- a/models.py
+++ b/models.py
@@ -35,7 +35,10 @@ class Node(db.Model):
 
     def mark_inactive(self):
         # TODO this is bad, need a good way to save unregistered node state
-        self.updated_at = datetime.utcnow() - AVAILABILITY_TIMEOUT
+        # time in percona is rounded to seconds,
+        # so need additional 1 second to ensure node becomes inactive instantly
+        value = datetime.utcnow() - AVAILABILITY_TIMEOUT - timedelta(seconds=1)
+        self.updated_at = value
 
     def get_service_proposals(self):
         try:
@@ -115,7 +118,8 @@ class Identity(db.Model):
 def _is_active(last_update_time):
     if last_update_time is None:
         return False
-    return last_update_time > datetime.utcnow() - AVAILABILITY_TIMEOUT
+    passed = datetime.utcnow() - last_update_time
+    return passed < AVAILABILITY_TIMEOUT
 
 
 class IdentityRegistration(db.Model):

--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ from tornado.ioloop import IOLoop
 from app import app, init_db
 import settings
 
+print('starting server')
 init_db()
 
 http_server = HTTPServer(WSGIContainer(app))

--- a/settings.py
+++ b/settings.py
@@ -8,6 +8,13 @@ DB_NAME = os.environ.get('DB_NAME') or ''
 USER = os.environ.get('DB_USER') or ''
 PASSWD = os.environ.get('DB_PASSWORD') or ''
 
+DB_CONFIG = {
+    'host': DB_HOST,
+    'name': DB_NAME,
+    'user': USER,
+    'passwd': PASSWD
+}
+
 # util.strtobool
 # True values are y, yes, t, true, on and 1;
 # False values are n, no, f, false, off and 0.

--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,8 @@ DB_CONFIG = {
     'passwd': PASSWD
 }
 
+DISABLE_LOGS = os.environ.get('DISABLE_LOGS') or False
+
 # util.strtobool
 # True values are y, yes, t, true, on and 1;
 # False values are n, no, f, false, off and 0.

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+
+  api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: mysterium-api-test
+    environment:
+      APP_PORT: 80
+      DB_HOST: mysterium-mysql-test
+      DB_NAME: myst_api
+      DB_USER: myst_api
+      DB_PASSWORD: myst_api
+    volumes:
+      - ..:/code
+    depends_on:
+      - db
+
+  db:
+    image: percona:5.7
+    container_name: mysterium-mysql-test
+    ports:
+      - 33062:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: myst_api
+      MYSQL_USER: myst_api
+      MYSQL_PASSWORD: myst_api

--- a/tests/endpoints/test_identities.py
+++ b/tests/endpoints/test_identities.py
@@ -1,10 +1,11 @@
-from tests.test_case import TestCase, main
+from tests.test_case import TestCase
 from tests.utils import (
     build_test_authorization,
     build_static_public_address
 )
 from models import IdentityRegistration
 import json
+from models import db
 
 
 class TestIdentities(TestCase):
@@ -76,8 +77,8 @@ class TestIdentities(TestCase):
     def test_payout_update(self):
         identity = build_static_public_address().upper()
         pre_record = IdentityRegistration(identity.lower(), '')
-        main.db.session.add(pre_record)
-        main.db.session.commit()
+        db.session.add(pre_record)
+        db.session.commit()
 
         payload = {
             'payout_eth_address': '0x000000000000000000000000000000000000000a'
@@ -103,8 +104,8 @@ class TestIdentities(TestCase):
         identity = build_static_public_address().upper()
         eth_address = build_static_public_address().upper()
         pre_record = IdentityRegistration(identity.lower(), eth_address)
-        main.db.session.add(pre_record)
-        main.db.session.commit()
+        db.session.add(pre_record)
+        db.session.commit()
 
         auth = build_test_authorization()
         re = self._get(
@@ -131,8 +132,8 @@ class TestIdentities(TestCase):
         other_identity = '0X000000000000000000000000000000000000000A'
         eth_address = build_static_public_address().upper()
         pre_record = IdentityRegistration(other_identity.lower(), eth_address)
-        main.db.session.add(pre_record)
-        main.db.session.commit()
+        db.session.add(pre_record)
+        db.session.commit()
 
         auth = build_test_authorization()
         re = self._get(

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+(cd tests; docker-compose up --build -d)
+echo "Sleeping for 10s until everything initializes"
+sleep 10
+(cd tests; docker-compose exec api bin/db-upgrade)
+
+bin/test

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 (cd tests; docker-compose up --build -d)
-echo "Sleeping for 10s until everything initializes"
+printf "Sleeping for 10s until everything initializes...\n"
 sleep 10
 (cd tests; docker-compose exec api bin/db-upgrade)
 
-bin/test
+DISABLE_LOGS=1 bin/test

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,20 +1,27 @@
 from flask_testing import TestCase
-import app as main
+from app import app, init_db
 import json
+from models import db
 
 
 class TestCase(TestCase):
     def create_app(self):
-        main.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
-        main.db.init_app(main.app)
-        return main.app
+        db_config = {
+            'host': 'localhost:33062',
+            'name': 'myst_api',
+            'user': 'myst_api',
+            'passwd': 'myst_api'
+        }
+
+        init_db(db_config)
+        return app
 
     def setUp(self):
-        main.db.create_all()
+        db.create_all()
 
     def tearDown(self):
-        main.db.session.remove()
-        main.db.drop_all()
+        db.session.remove()
+        db.drop_all()
 
     # TODO: find better place to move constant
     REMOTE_ADDR = '8.8.8.8'

--- a/tests/test_save_identity.py
+++ b/tests/test_save_identity.py
@@ -1,7 +1,7 @@
 import unittest
-from tests.test_case import TestCase, main
+from tests.test_case import TestCase
 from tests.utils import build_test_authorization
-from models import Identity
+from models import db, Identity
 
 
 class TestSaveIdentity(TestCase):
@@ -21,7 +21,7 @@ class TestSaveIdentity(TestCase):
         auth = build_test_authorization()
 
         identity_record = Identity(auth['public_address'])
-        main.db.session.add(identity_record)
+        db.session.add(identity_record)
 
         re = self.client.post(
             '/v1/identities',


### PR DESCRIPTION
I wanted to add a test for dashboard home, but this wasn't easy - our custom SQL queries are not supported by SQLite, which we use for tests.
Added new `docker-compose.yml` for running tests with real DB.
This got a bit complex, so I'd like to get some feedback before finishing it (it's WIP).