### PR TITLE
Optimize dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mysterium Network API
 
-[![Build Status](https://travis-ci.org/MysteriumNetwork/api.svg?branch=master)](https://travis-ci.org/MysteriumNetwork/api)
+[![Build Status](https://travis-ci.com/mysteriumnetwork/api.svg?branch=master)](https://travis-ci.com/mysteriumnetwork/api)
 [![pyVersion36](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/)
 
 API for Node & Client

--- a/api/stats/model_layer.py
+++ b/api/stats/model_layer.py
@@ -87,9 +87,6 @@ def get_available_nodes(limit=None):
         node.country_string = get_country_string(
             node.get_country_from_service_proposal()
         )
-        node.sessions_count = get_sessions_count_by_service_type(
-            node.node_key, node.service_type
-        )
         delta = datetime.utcnow() - node.updated_at
         node.last_seen = delta.total_seconds()
     return nodes

--- a/api/stats/model_layer.py
+++ b/api/stats/model_layer.py
@@ -75,12 +75,8 @@ def get_country_string(country):
     return country or 'N/A'
 
 
-def get_available_nodes(limit=None):
+def get_available_nodes():
     nodes = filter_active_nodes()
-
-    if limit:
-        nodes = nodes.limit(limit)
-
     nodes = nodes.all()
 
     for node in nodes:

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -14,7 +14,6 @@ from api.stats.model_layer import (
 from api.stats.node_list import get_nodes
 from dashboard.settings import (
     METRICS_CACHE_TIMEOUT,
-    DASHBOARD_CACHE_TIMEOUT,
     VIEW_SESSIONS_CACHE_TIMEOUT
 )
 from api.settings import DB_CONFIG
@@ -68,17 +67,9 @@ def collect_metrics():
 
 @app.route('/')
 def main():
-    dashboard_data = cache.get('dashboard-data')
-    if dashboard_data is None:
-        dashboard_data = {
-            'available_nodes': get_available_nodes(limit=10),
-            'sessions': fetch_sessions(10),
-        }
-        cache.set(
-            'dashboard-data',
-            dashboard_data,
-            timeout=DASHBOARD_CACHE_TIMEOUT
-        )
+    dashboard_data = {
+        'available_nodes': get_available_nodes(limit=10),
+    }
 
     page_content = render_template(
         'dashboard.html',

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -99,15 +99,15 @@ def leaderboard():
 def node(key, service_type):
     node = get_node_info(key, service_type)
     return render_template(
-        'node.html',
+        'service.html',
         node=node,
     )
 
 
-@app.route('/nodes')
+@app.route('/services')
 def nodes():
     return render_template(
-        'nodes.html',
+        'services.html',
         nodes=get_nodes()
     )
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -68,7 +68,7 @@ def collect_metrics():
 @app.route('/')
 def main():
     dashboard_data = {
-        'available_nodes': get_available_nodes(limit=10),
+        'available_nodes': get_available_nodes(),
     }
 
     page_content = render_template(

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -5,8 +5,5 @@ API_HOST = os.environ.get('API_HOST') or 'http://localhost:8001'
 METRICS_CACHE_TIMEOUT = os.environ.get('METRICS_CACHE_TIMEOUT') \
                         or 5 * 60  # in seconds
 
-DASHBOARD_CACHE_TIMEOUT = os.environ.get('DASHBOARD_CACHE_TIMEOUT') \
-                        or 1 * 60  # in seconds
-
 VIEW_SESSIONS_CACHE_TIMEOUT = os.environ.get('VIEW_SESSIONS_CACHE_TIMEOUT') \
                         or 1 * 60  # in seconds

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -12,7 +12,7 @@
             <div class="col-xs-12">
               <div class="x_panel">
                 <div class="x_title">
-                  <h2>Available Nodes <small><a href="/nodes">view all</a></small></h2>
+                  <h2>Available Services <small><a href="/services">view all</a></small></h2>
                   <div class="clearfix"></div>
                 </div>
                 <div class="x_content">
@@ -23,7 +23,7 @@
                         <th class="enumerator">#</th>
                         <th>Node</th>
                         <th>Service</th>
-                        <th>Type</th>
+                        <th>Node Type</th>
                         <th>Country</th>
                         <th>Seen</th>
                       </tr>

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -9,10 +9,10 @@
           <br />
 
           <div class="row">
-            <div class="col-md-7 col-sm-7 col-xs-12">
+            <div class="col-xs-12">
               <div class="x_panel">
                 <div class="x_title">
-                  <h2>Available Nodes <small><a href="/nodes">view more</a></small></h2>
+                  <h2>Available Nodes <small><a href="/nodes">view all</a></small></h2>
                   <div class="clearfix"></div>
                 </div>
                 <div class="x_content">
@@ -25,7 +25,6 @@
                         <th>Service</th>
                         <th>Type</th>
                         <th>Country</th>
-                        <th>Sessions</th>
                         <th>Seen</th>
                       </tr>
                     </thead>
@@ -37,7 +36,6 @@
                         <td>{{node.service_type}}</td>
                         <td>{{node.node_type.capitalize()}}</td>
                         <td>{{node.country_string}}</td>
-                        <td>{{node.sessions_count}}</td>
                         <td>{{node.last_seen|format_time}}</td>
                       </tr>
                       {% endfor %}
@@ -47,42 +45,6 @@
                 </div>
               </div>
             </div>
-
-            <div class="col-md-5 col-sm-5 col-xs-12">
-              <div class="x_panel">
-                <div class="x_title">
-                  <h2>Latest Sessions <small><a href="/sessions">view more</a></small></h2>
-                  <div class="clearfix"></div>
-                </div>
-                <div class="x_content">
-
-                  <table class="table table-hover clickable">
-                    <thead>
-                      <tr>
-                        <th class="enumerator">#</th>
-                        <th>Duration</th>
-                        <th>Data Transferred</th>
-                        <th>Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-
-                    {% for se in sessions %}
-                    <tr onclick="window.document.location='/session/{{se.session_key}}'">
-                      <td scope="row" class="enumerator">{{loop.index}}</td>
-                      <td>{{se.duration|format_duration}}</td>
-                      <td>{{se.data_transferred|format_bytes_count}}</td>
-                      <td>{{se.status}}</td>
-                    </tr>
-                    {% endfor %}
-
-                    </tbody>
-                  </table>
-
-                </div>
-              </div>
-            </div>
-
 
           </div>
 

--- a/dashboard/templates/leaderboard.html
+++ b/dashboard/templates/leaderboard.html
@@ -16,10 +16,10 @@
                         <th>Node</th>
                         <th>Monthly Availability</th>
                         <th>Data Transferred</th>
-                        <th>Sessions</th>
+                        <th class="mobile-hide">Sessions</th>
                         <th class="mobile-hide">Unique Users</th>
-                        <th class="mobile-hide">Country</th>
-                        <th class="mobile-hide">Status</th>
+                        <th>Country</th>
+                        <th>Status</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -29,10 +29,16 @@
                         <td class="td-node-key">{{row.provider_id}}</td>
                         <td>{{row.availability}}</td>
                         <td>{{row.total_bytes|format_bytes_count}}</td>
-                        <td>{{row.sessions_count}}</td>
+                        <td class="mobile-hide">{{row.sessions_count}}</td>
                         <td class="mobile-hide">{{row.unique_users}}</td>
-                        <td class="mobile-hide">{{row.country}}</td>
-                        <td class="mobile-hide">{{row.service_status}}</td>
+                        <td>{{row.country}}</td>
+                        <td>
+                          {% if row.service_status == 'Online' %}
+                            <i class="fa fa-circle green" aria-hidden="true" title="Online"></i>
+                          {% else %}
+                            <i class="fa fa-circle" aria-hidden="true" title="Offline"></i>
+                          {% endif %}
+                        </td>
                       </tr>
                       {% endfor %}
                     </tbody>

--- a/dashboard/templates/network_metrics.html
+++ b/dashboard/templates/network_metrics.html
@@ -1,7 +1,7 @@
   <!-- top tiles -->
   <div class="row tile_count">
     <div class="col-md-2 col-sm-4 col-xs-6 tile_stats_count">
-      <span class="count_top"><i class="fa fa-wifi"></i> Available Nodes</span>
+      <span class="count_top"><i class="fa fa-wifi"></i> Available Provider Nodes</span>
       <div class="count green">{{active_nodes_count}}</div>
     </div>
     <div class="col-md-2 col-sm-4 col-xs-6 tile_stats_count">

--- a/dashboard/templates/nodes.html
+++ b/dashboard/templates/nodes.html
@@ -16,11 +16,11 @@
                 <tr>
                   <th class="enumerator">#</th>
                   <th>Node</th>
-                  <th>Status</th>
-                  <th>Seen</th>
-                  <th>Country</th>
                   <th class="mobile-hide">Service</th>
                   <th class="mobile-hide">Type</th>
+                  <th>Country</th>
+                  <th>Seen</th>
+                  <th>Status</th>
                 </tr>
               </thead>
               <tbody>
@@ -28,11 +28,17 @@
                 <tr onclick="window.document.location='/node/{{node.node_key}}/{{node.service_type}}'">
                   <td scope="row" class="enumerator">{{loop.index}}</td>
                   <td class="td-node-key">{{node.node_key}}</td>
-                  <td>{{node.status()}}</td>
-                  <td>{{node.last_seen|format_time}}</td>
-                  <td>{{node.country_string}}</td>
                   <td class="mobile-hide">{{node.service_type}}</td>
                   <td class="mobile-hide">{{node.node_type.capitalize()}}</td>
+                  <td>{{node.country_string}}</td>
+                  <td>{{node.last_seen|format_time}}</td>
+                  <td>
+                    {% if node.status() == 'Online' %}
+                      <i class="fa fa-circle green" aria-hidden="true" title="Online"></i>
+                    {% else %}
+                      <i class="fa fa-circle" aria-hidden="true" title="Offline"></i>
+                    {% endif %}
+                  </td>
                 </tr>
                 {% endfor %}
               </tbody>

--- a/dashboard/templates/service.html
+++ b/dashboard/templates/service.html
@@ -4,7 +4,7 @@
 
     <div class="page-title">
       <div class="title_left">
-        <h3>Node </h3>
+        <h3>Service </h3>
           <div class="key">{{ node.node_key }}</div>
       </div>
     </div>

--- a/dashboard/templates/services.html
+++ b/dashboard/templates/services.html
@@ -6,7 +6,7 @@
       <div class="col-md-12 col-sm-6 col-xs-12">
         <div class="x_panel">
           <div class="x_title">
-            <h2>Nodes List</h2>
+            <h2>Services</h2>
             <div class="clearfix"></div>
           </div>
           <div class="x_content">

--- a/dashboard/tests/test_app.py
+++ b/dashboard/tests/test_app.py
@@ -31,34 +31,10 @@ class TestEndpoints(TestCase):
         self.assertEqual(200, re.status_code)
 
     @responses.activate
-    def test_home_handles_api_error(self):
-        self.mock_sessions(500, {'error': 'mock error'})
-        re = self._get('/')
-        self.assertEqual(503, re.status_code)
-
-    @responses.activate
-    def test_home_handles_api_invalid_json_response(self):
-        self.mock_sessions(200, body='mock response')
-        re = self._get('/')
-        self.assertEqual(503, re.status_code)
-
-    @responses.activate
-    def test_home_handles_api_invalid_json_response(self):
-        self.mock_sessions(200, body='mock response')
-        re = self._get('/')
-        self.assertEqual(503, re.status_code)
-
-    @responses.activate
     def test_sessions_succeds(self):
         self.mock_sessions(200, {'sessions': [self.mocked_session]})
         re = self._get('/sessions')
         self.assertEqual(200, re.status_code)
-
-    @responses.activate
-    def test_sessions_handles_api_error(self):
-        self.mock_sessions(500)
-        re = self._get('/sessions')
-        self.assertEqual(503, re.status_code)
 
     @responses.activate
     def test_sessions_handles_missing_data(self):


### PR DESCRIPTION
Fixes: mysteriumnetwork/node#1236

1. Remove session list from front page
2. Lift limit from available nodes list in front page (show all available nodes)
3. Remove session count from nodes list
4. Align terminology: node -> service
5. Replace status text with indicators