### PR TITLE
Store node availability data in batches

### DIFF
--- a/api/node_availability_worker.py
+++ b/api/node_availability_worker.py
@@ -1,8 +1,9 @@
 import threading
 import queue
 from sqlalchemy.orm import sessionmaker
+import logging
 
-
+logger = logging.getLogger('node_availability_worker')
 node_availability_queue = queue.Queue()
 node_availability_batch_size = 20
 
@@ -23,10 +24,9 @@ def process_node_availabilities(db_engine, availabilities_queue):
                 db_session.bulk_save_objects(batch)
                 db_session.commit()
                 batch = []
-                print("Committed node availability batch")
-                return
-        except Exception as e:
-            print("Failed to process node availabilities:", e)
+                logger.info("Committed node availability batch")
+        except Exception:
+            logger.error("Failed to process node availabilities:", exc_info=True)
             if db_session is not None:
                 db_session.rollback()
         finally:

--- a/api/node_availability_worker.py
+++ b/api/node_availability_worker.py
@@ -1,0 +1,39 @@
+import threading
+import queue
+from sqlalchemy.orm import sessionmaker
+
+
+node_availability_queue = queue.Queue()
+node_availability_batch_size = 20
+
+
+# process_node_availabilities processes node availability data
+# in batches and inserts to db. This work happens in a separate thread.
+def process_node_availabilities(db_engine, availabilities_queue):
+    session_factory = sessionmaker(bind=db_engine)
+
+    batch = []
+    db_session = None
+    while True:
+        try:
+            item = availabilities_queue.get()
+            batch.append(item)
+            if len(batch) >= node_availability_batch_size:
+                db_session = session_factory()
+                db_session.bulk_save_objects(batch)
+                db_session.commit()
+                batch = []
+                print("Committed node availability batch")
+                return
+        except Exception as e:
+            print("Failed to process node availabilities:", e)
+            if db_session is not None:
+                db_session.rollback()
+        finally:
+            if db_session is not None:
+                db_session.close()
+
+
+def start_node_availability_worker(db_engine, availabilities_queue):
+    x = threading.Thread(target=process_node_availabilities, args=(db_engine, availabilities_queue))
+    x.start()

--- a/api/node_availability_worker.py
+++ b/api/node_availability_worker.py
@@ -35,5 +35,5 @@ def process_node_availabilities(db_engine, availabilities_queue):
 
 
 def start_node_availability_worker(db_engine, availabilities_queue):
-    x = threading.Thread(target=process_node_availabilities, args=(db_engine, availabilities_queue))
+    x = threading.Thread(target=process_node_availabilities, args=(db_engine, availabilities_queue), daemon=True)
     x.start()

--- a/api/proposals.py
+++ b/api/proposals.py
@@ -197,5 +197,3 @@ def delete_proposal_policies(node_key):
 
 def generate_etag(obj):
     return hashlib.md5(json.dumps(obj).encode("utf-8")).hexdigest()
-
-

--- a/app.py
+++ b/app.py
@@ -24,8 +24,9 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 # app.config['SQLALCHEMY_RECORD_QUERIES'] = True
 #
 # Usage example inside endpoints.
-# info = get_debug_queries()[0]
-# print(info.statement, info.parameters, info.duration, sep='\n')
+# for info in get_debug_queries():
+#     print(info.statement, info.parameters, info.duration, sep='\n')
+#     print('\n')
 
 CORS(app, resources=[r'/v1/affiliates'])
 register_proposal_endpoints(app)

--- a/server.py
+++ b/server.py
@@ -1,11 +1,15 @@
 from tornado.wsgi import WSGIContainer
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
+
+from api.node_availability_worker import start_node_availability_worker, node_availability_queue
 from app import app, init_db
 from api import settings
+from models import db
 
 print('starting server')
 init_db()
+start_node_availability_worker(db.get_engine(app), node_availability_queue)
 
 http_server = HTTPServer(WSGIContainer(app))
 http_server.listen(settings.APP_PORT)

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -1,5 +1,9 @@
 import json
+import time
 from datetime import datetime, timedelta
+
+from api.node_availability_worker import node_availability_batch_size, start_node_availability_worker, \
+    node_availability_queue, process_node_availabilities
 from models import (
     db, Node, ProposalAccessPolicy, AVAILABILITY_TIMEOUT, IdentityRegistration,
     NodeAvailability
@@ -778,38 +782,31 @@ class TestProposals(TestCase):
         data = json.loads(re.data)
         self.assertEqual(1, len(data['proposals']))
 
-    def test_ping_proposal(self):
-        payload = {}
-        auth = build_test_authorization(json.dumps(payload))
-
-        self._create_node(auth['public_address'], "openvpn")
-
-        re = self._post(
-            '/v1/ping_proposal',
-            payload,
-            headers=auth['headers']
-        )
-        self.assertEqual(200, re.status_code)
-        self.assertEqual({}, re.json)
-        pings = NodeAvailability.query.all()
-        self.assertEqual(pings[0].service_type, "openvpn")
-
     def test_ping_proposal_with_service_type(self):
-        payload = {'service_type': 'dummy'}
+        payload = {'service_type': 'dummy_service'}
         auth = build_test_authorization(json.dumps(payload))
 
-        self._create_node(auth['public_address'], "dummy")
+        self._create_node(auth['public_address'], "dummy_service")
 
-        re = self._post(
-            '/v1/ping_proposal',
-            payload,
-            headers=auth['headers']
-        )
-        self.assertEqual(200, re.status_code)
+        re = Node
+        for i in range(node_availability_batch_size):
+            re = self._post(
+                '/v1/ping_proposal',
+                payload,
+                headers=auth['headers']
+            )
+            self.assertEqual(200, re.status_code)
+
+        process_node_availabilities(db.engine, node_availability_queue)
+
+        # Detach current session so NodeAvailability model can pick new changes inserted from another session.
+        db.session.remove()
+        pings = NodeAvailability.query.filter(
+            getattr(NodeAvailability, 'service_type') == payload['service_type']
+        ).all()
+
         self.assertEqual({}, re.json)
-
-        pings = NodeAvailability.query.all()
-        self.assertEqual(pings[0].service_type, "dummy")
+        self.assertEqual(pings[0].service_type, "dummy_service")
 
     def test_ping_proposal_no_node_with_service_type(self):
         payload = {'service_type': 'dummy'}

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -2,8 +2,10 @@ import json
 import time
 from datetime import datetime, timedelta
 
-from api.node_availability_worker import node_availability_batch_size, start_node_availability_worker, \
-    node_availability_queue, process_node_availabilities
+from api.node_availability_worker import (
+    node_availability_batch_size, start_node_availability_worker,
+    node_availability_queue
+)
 from models import (
     db, Node, ProposalAccessPolicy, AVAILABILITY_TIMEOUT, IdentityRegistration,
     NodeAvailability
@@ -783,6 +785,8 @@ class TestProposals(TestCase):
         self.assertEqual(1, len(data['proposals']))
 
     def test_ping_proposal_with_service_type(self):
+        start_node_availability_worker(db.engine, node_availability_queue)
+
         payload = {'service_type': 'dummy_service'}
         auth = build_test_authorization(json.dumps(payload))
 
@@ -797,7 +801,8 @@ class TestProposals(TestCase):
             )
             self.assertEqual(200, re.status_code)
 
-        process_node_availabilities(db.engine, node_availability_queue)
+        # Sleep for some time to wait for inserted availabilities.
+        time.sleep(3)
 
         # Detach current session so NodeAvailability model can pick new changes inserted from another session.
         db.session.remove()


### PR DESCRIPTION
Storing this way should optimize data insertion and use less RDS IOPS.