### PR TITLE
Add mobile android update min version

### DIFF
--- a/api/mobile.py
+++ b/api/mobile.py
@@ -1,0 +1,12 @@
+from flask import jsonify
+
+
+MIN_ANDROID_VERSION = "0.34.1"
+
+
+def register_endpoints(app):
+    @app.route('/v1/mobile/android/versions', methods=['GET'])
+    def min_version():
+        return jsonify({
+            'min_version': MIN_ANDROID_VERSION
+        })

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from api.identities import register_endpoints as register_identity_endpoints
 from api.sessions import register_endpoints as register_session_endpoints
 from api.statistics import register_endpoints as register_statistic_endpoints
 from api.affiliates import register_endpoints as register_affiliates_endpoints
+from api.mobile import register_endpoints as register_mobile_endpoints
 
 if not settings.DISABLE_LOGS:
     helpers.setup_logger()
@@ -34,6 +35,7 @@ register_identity_endpoints(app)
 register_session_endpoints(app)
 register_statistic_endpoints(app)
 register_affiliates_endpoints(app)
+register_mobile_endpoints(app)
 
 
 def _generate_database_uri(db_config):

--- a/tests/test_mobile.py
+++ b/tests/test_mobile.py
@@ -1,0 +1,11 @@
+import json
+from flask import jsonify
+
+from tests.test_case import TestCase
+from api.mobile import MIN_ANDROID_VERSION
+
+
+class TestMobile(TestCase):
+    def test_update_min_version(self):
+        res = self._get('/v1/mobile/android/versions')
+        self.assertEqual({'min_version': MIN_ANDROID_VERSION}, res.json)


### PR DESCRIPTION
Endpoint will be used when android app launches to check minimum required version for force update.